### PR TITLE
Switched to encrypt-then-authenticate paradigm

### DIFF
--- a/README
+++ b/README
@@ -83,7 +83,7 @@ knockknock Overview:
     That's it.  Written in python, simple, single-packet, secure.
   
     The request is encrypted using AES in CTR mode, with an HMAC-SHA1
-    using the authenticate-then-encrypt paradigm.  It protects against
+    using the encrypt-then-authenticate paradigm.  It protects against
     evesdropping, replay attacks, and all known forms of cryptanalysis
     against IND-CCA secure schemes.
   


### PR DESCRIPTION
Changed the scheme from authenticate-then-encrypt to
encrypt-then-authenticate. The MAC is now computed on the current
counter and the encrypted port and then appended to the ciphertext.

This patch should resolve issue #4.
